### PR TITLE
chore: move db statements to another trait

### DIFF
--- a/migra-cli/src/database/clients/mysql.rs
+++ b/migra-cli/src/database/clients/mysql.rs
@@ -22,15 +22,16 @@ impl OpenDatabaseConnection for MySqlConnection {
     }
 }
 
-impl DatabaseConnection for MySqlConnection {
-    fn migration_table_stmt(&self) -> String {
+impl DatabaseStatements for MySqlConnection {
+    fn create_migration_table_stmt(&self) -> &'static str {
         r#"CREATE TABLE IF NOT EXISTS migrations (
             id      int             AUTO_INCREMENT PRIMARY KEY,
             name    varchar(256)    NOT NULL UNIQUE
         )"#
-        .to_string()
     }
+}
 
+impl DatabaseConnection for MySqlConnection {
     fn batch_execute(&mut self, query: &str) -> StdResult<()> {
         self.client()?.query_drop(query)?;
         Ok(())

--- a/migra-cli/src/database/clients/postgres.rs
+++ b/migra-cli/src/database/clients/postgres.rs
@@ -14,15 +14,16 @@ impl OpenDatabaseConnection for PostgresConnection {
     }
 }
 
-impl DatabaseConnection for PostgresConnection {
-    fn migration_table_stmt(&self) -> String {
+impl DatabaseStatements for PostgresConnection {
+    fn create_migration_table_stmt(&self) -> &'static str {
         r#"CREATE TABLE IF NOT EXISTS migrations (
             id      serial      PRIMARY KEY,
             name    text        NOT NULL UNIQUE
         )"#
-        .to_string()
     }
+}
 
+impl DatabaseConnection for PostgresConnection {
     fn batch_execute(&mut self, query: &str) -> StdResult<()> {
         self.client.batch_execute(query)?;
         Ok(())

--- a/migra-cli/src/database/connection.rs
+++ b/migra-cli/src/database/connection.rs
@@ -9,9 +9,11 @@ pub trait OpenDatabaseConnection: Sized {
     fn open(connection_string: &str) -> StdResult<Self>;
 }
 
-pub trait DatabaseConnection {
-    fn migration_table_stmt(&self) -> String;
+pub trait DatabaseStatements {
+    fn create_migration_table_stmt(&self) -> &'static str;
+}
 
+pub trait DatabaseConnection: DatabaseStatements {
     fn batch_execute(&mut self, query: &str) -> StdResult<()>;
 
     fn execute<'b>(&mut self, query: &str, params: ToSqlParams<'b>) -> StdResult<u64>;

--- a/migra-cli/src/database/migration.rs
+++ b/migra-cli/src/database/migration.rs
@@ -104,7 +104,7 @@ impl ManageMigration for MigrationManager {
     }
 
     fn create_migrations_table(&self, conn: &mut AnyConnection) -> StdResult<()> {
-        let stmt = conn.migration_table_stmt();
+        let stmt = conn.create_migration_table_stmt();
         conn.batch_execute(&stmt)
     }
 

--- a/migra-cli/src/database/mod.rs
+++ b/migra-cli/src/database/mod.rs
@@ -7,7 +7,9 @@ pub(crate) mod transaction;
 
 pub mod prelude {
     pub use super::adapter::{ToSql, ToSqlParams, TryFromSql};
-    pub use super::connection::{AnyConnection, DatabaseConnection, OpenDatabaseConnection};
+    pub use super::connection::{
+        AnyConnection, DatabaseConnection, DatabaseStatements, OpenDatabaseConnection,
+    };
     pub use super::migration::ManageMigration;
     pub use super::transaction::ManageTransaction;
 }


### PR DESCRIPTION
I thought it would be cleaner code if we put the statements in a separate trait